### PR TITLE
Fix msi upgrade

### DIFF
--- a/.github/resources/Beat Link Trigger.wxs
+++ b/.github/resources/Beat Link Trigger.wxs
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+    <Product Id="*" Name="Beat Link Trigger" Language="1033" Version="$(var.bltversion)" Manufacturer="Deep Symmetry, LLC" UpgradeCode="6D58C8D7-6163-43C6-93DC-A4C8CC1F81B6">
+        <Package InstallerVersion="200" Compressed="yes" Platform="x64" />
+        <Upgrade Id="6D58C8D7-6163-43C6-93DC-A4C8CC1F81B6" />
+        <MajorUpgrade Schedule="afterInstallInitialize" AllowDowngrades="no" AllowSameVersionUpgrades="yes" DowngradeErrorMessage="A newer version of [ProductName] is already installed." />
+        <Media Id="1" Cabinet="BeatLinkTrigger.cab" EmbedCab="yes" />
+        <Directory Id="TARGETDIR" Name="SourceDir">
+            <Directory Id="ProgramFiles64Folder" Name="PFiles64">
+                <Directory Id="ProgramMenuFolder">
+                    <Directory Id="ProgramMenuDir" Name="Deep Symmetry">
+                        <Component Id="StartMenuShortcuts" Guid="0A548DE0-FE47-40E2-BEAF-8E35E5AA07F3">
+                            <RemoveFolder Id="ProgramMenuDir" On="uninstall" />
+                            <RegistryValue Root="HKCU" Key="Software\[Manufacturer]\[ProductName]" Type="string" Value="" />
+                            <Shortcut Id="BeatLinkTrigger" Name="Beat Link Trigger" Description="Start Beat Link Trigger" Target="[DEEP_SYMMETRY]\Beat Link Trigger\BEAT LINK TRIGGER.EXE" Icon="Beat_Link_Trigger.ico">
+                            </Shortcut>
+                        </Component>
+                    </Directory>
+                </Directory>
+                <Directory Id="DEEP_SYMMETRY" Name="Deep Symmetry">
+                </Directory>
+			</Directory>
+        </Directory>
+        <Feature Id="DefaultFeature" Title="Main Feature" Level="1">
+            <ComponentRef Id="StartMenuShortcuts" />
+			<ComponentGroupRef Id="BEAT_LINK_TRIGGER" />
+        </Feature>
+        <UI />
+        <Property Id="WIXUI_INSTALLDIR" Value="DEEP_SYMMETRY" />
+        <Property Id="ARPPRODUCTICON" Value="Beat_Link_Trigger.ico" />
+        <WixVariable Id="WixUILicenseRtf" Value=".\.github\resources\LICENSE.RTF" />
+        <UIRef Id="WixUI_InstallDir" />
+        <Icon Id="Beat_Link_Trigger.ico" SourceFile=".\.github\resources\BeatLink.ico" />
+        <InstallExecuteSequence>
+            <FindRelatedProducts />
+        </InstallExecuteSequence>
+        <Condition Message="This installer is only supported on Windows 10 64 Bit. You will still be able to use Beat Link Trigger if you download and install Orace Java Runtime Environment (JRE) yourself. After that you can run the .jar file which can be downloaded at the Beat Link Trigger project on Github">
+			<![CDATA[Installed OR VersionNT64]]>
+		</Condition>
+    </Product>
+</Wix>

--- a/.github/resources/LICENSE.RTF
+++ b/.github/resources/LICENSE.RTF
@@ -1,0 +1,218 @@
+{\rtf1\ansi\ansicpg1252\deff0\nouicompat\deflang1033{\fonttbl{\f0\fnil\fcharset0 Calibri;}}
+{\*\generator Riched20 10.0.17763}\viewkind4\uc1 
+\pard\sa200\sl276\slmult1\f0\fs22\lang9 THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE PUBLIC\par
+LICENSE ("AGREEMENT"). ANY USE, REPRODUCTION OR DISTRIBUTION OF THE PROGRAM\par
+CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.\par
+\par
+1. DEFINITIONS\par
+\par
+"Contribution" means:\par
+\par
+a) in the case of the initial Contributor, the initial code and\par
+documentation distributed under this Agreement, and\par
+\par
+b) in the case of each subsequent Contributor:\par
+\par
+i) changes to the Program, and\par
+\par
+ii) additions to the Program;\par
+\par
+where such changes and/or additions to the Program originate from and are\par
+distributed by that particular Contributor. A Contribution 'originates' from\par
+a Contributor if it was added to the Program by such Contributor itself or\par
+anyone acting on such Contributor's behalf. Contributions do not include\par
+additions to the Program which: (i) are separate modules of software\par
+distributed in conjunction with the Program under their own license\par
+agreement, and (ii) are not derivative works of the Program.\par
+\par
+"Contributor" means any person or entity that distributes the Program.\par
+\par
+"Licensed Patents" mean patent claims licensable by a Contributor which are\par
+necessarily infringed by the use or sale of its Contribution alone or when\par
+combined with the Program.\par
+\par
+"Program" means the Contributions distributed in accordance with this\par
+Agreement.\par
+\par
+"Recipient" means anyone who receives the Program under this Agreement,\par
+including all Contributors.\par
+\par
+2. GRANT OF RIGHTS\par
+\par
+a) Subject to the terms of this Agreement, each Contributor hereby grants\par
+Recipient a non-exclusive, worldwide, royalty-free copyright license to\par
+reproduce, prepare derivative works of, publicly display, publicly perform,\par
+distribute and sublicense the Contribution of such Contributor, if any, and\par
+such derivative works, in source code and object code form.\par
+\par
+b) Subject to the terms of this Agreement, each Contributor hereby grants\par
+Recipient a non-exclusive, worldwide, royalty-free patent license under\par
+Licensed Patents to make, use, sell, offer to sell, import and otherwise\par
+transfer the Contribution of such Contributor, if any, in source code and\par
+object code form.  This patent license shall apply to the combination of the\par
+Contribution and the Program if, at the time the Contribution is added by the\par
+Contributor, such addition of the Contribution causes such combination to be\par
+covered by the Licensed Patents. The patent license shall not apply to any\par
+other combinations which include the Contribution. No hardware per se is\par
+licensed hereunder.\par
+\par
+c) Recipient understands that although each Contributor grants the licenses\par
+to its Contributions set forth herein, no assurances are provided by any\par
+Contributor that the Program does not infringe the patent or other\par
+intellectual property rights of any other entity. Each Contributor disclaims\par
+any liability to Recipient for claims brought by any other entity based on\par
+infringement of intellectual property rights or otherwise. As a condition to\par
+exercising the rights and licenses granted hereunder, each Recipient hereby\par
+assumes sole responsibility to secure any other intellectual property rights\par
+needed, if any. For example, if a third party patent license is required to\par
+allow Recipient to distribute the Program, it is Recipient's responsibility\par
+to acquire that license before distributing the Program.\par
+\par
+d) Each Contributor represents that to its knowledge it has sufficient\par
+copyright rights in its Contribution, if any, to grant the copyright license\par
+set forth in this Agreement.\par
+\par
+3. REQUIREMENTS\par
+\par
+A Contributor may choose to distribute the Program in object code form under\par
+its own license agreement, provided that:\par
+\par
+a) it complies with the terms and conditions of this Agreement; and\par
+\par
+b) its license agreement:\par
+\par
+i) effectively disclaims on behalf of all Contributors all warranties and\par
+conditions, express and implied, including warranties or conditions of title\par
+and non-infringement, and implied warranties or conditions of merchantability\par
+and fitness for a particular purpose;\par
+\par
+ii) effectively excludes on behalf of all Contributors all liability for\par
+damages, including direct, indirect, special, incidental and consequential\par
+damages, such as lost profits;\par
+\par
+iii) states that any provisions which differ from this Agreement are offered\par
+by that Contributor alone and not by any other party; and\par
+\par
+iv) states that source code for the Program is available from such\par
+Contributor, and informs licensees how to obtain it in a reasonable manner on\par
+or through a medium customarily used for software exchange.\par
+\par
+When the Program is made available in source code form:\par
+\par
+a) it must be made available under this Agreement; and\par
+\par
+b) a copy of this Agreement must be included with each copy of the Program.\par
+\par
+Contributors may not remove or alter any copyright notices contained within\par
+the Program.\par
+\par
+Each Contributor must identify itself as the originator of its Contribution,\par
+if any, in a manner that reasonably allows subsequent Recipients to identify\par
+the originator of the Contribution.\par
+\par
+4. COMMERCIAL DISTRIBUTION\par
+\par
+Commercial distributors of software may accept certain responsibilities with\par
+respect to end users, business partners and the like. While this license is\par
+intended to facilitate the commercial use of the Program, the Contributor who\par
+includes the Program in a commercial product offering should do so in a\par
+manner which does not create potential liability for other Contributors.\par
+Therefore, if a Contributor includes the Program in a commercial product\par
+offering, such Contributor ("Commercial Contributor") hereby agrees to defend\par
+and indemnify every other Contributor ("Indemnified Contributor") against any\par
+losses, damages and costs (collectively "Losses") arising from claims,\par
+lawsuits and other legal actions brought by a third party against the\par
+Indemnified Contributor to the extent caused by the acts or omissions of such\par
+Commercial Contributor in connection with its distribution of the Program in\par
+a commercial product offering.  The obligations in this section do not apply\par
+to any claims or Losses relating to any actual or alleged intellectual\par
+property infringement. In order to qualify, an Indemnified Contributor must:\par
+a) promptly notify the Commercial Contributor in writing of such claim, and\par
+b) allow the Commercial Contributor tocontrol, and cooperate with the\par
+Commercial Contributor in, the defense and any related settlement\par
+negotiations. The Indemnified Contributor may participate in any such claim\par
+at its own expense.\par
+\par
+For example, a Contributor might include the Program in a commercial product\par
+offering, Product X. That Contributor is then a Commercial Contributor. If\par
+that Commercial Contributor then makes performance claims, or offers\par
+warranties related to Product X, those performance claims and warranties are\par
+such Commercial Contributor's responsibility alone. Under this section, the\par
+Commercial Contributor would have to defend claims against the other\par
+Contributors related to those performance claims and warranties, and if a\par
+court requires any other Contributor to pay any damages as a result, the\par
+Commercial Contributor must pay those damages.\par
+\par
+5. NO WARRANTY\par
+\par
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, THE PROGRAM IS PROVIDED ON\par
+AN "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER\par
+EXPRESS OR IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR\par
+CONDITIONS OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A\par
+PARTICULAR PURPOSE. Each Recipient is solely responsible for determining the\par
+appropriateness of using and distributing the Program and assumes all risks\par
+associated with its exercise of rights under this Agreement , including but\par
+not limited to the risks and costs of program errors, compliance with\par
+applicable laws, damage to or loss of data, programs or equipment, and\par
+unavailability or interruption of operations.\par
+\par
+6. DISCLAIMER OF LIABILITY\par
+\par
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, NEITHER RECIPIENT NOR ANY\par
+CONTRIBUTORS SHALL HAVE ANY LIABILITY FOR ANY DIRECT, INDIRECT, INCIDENTAL,\par
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING WITHOUT LIMITATION\par
+LOST PROFITS), HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN\par
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)\par
+ARISING IN ANY WAY OUT OF THE USE OR DISTRIBUTION OF THE PROGRAM OR THE\par
+EXERCISE OF ANY RIGHTS GRANTED HEREUNDER, EVEN IF ADVISED OF THE POSSIBILITY\par
+OF SUCH DAMAGES.\par
+\par
+7. GENERAL\par
+\par
+If any provision of this Agreement is invalid or unenforceable under\par
+applicable law, it shall not affect the validity or enforceability of the\par
+remainder of the terms of this Agreement, and without further action by the\par
+parties hereto, such provision shall be reformed to the minimum extent\par
+necessary to make such provision valid and enforceable.\par
+\par
+If Recipient institutes patent litigation against any entity (including a\par
+cross-claim or counterclaim in a lawsuit) alleging that the Program itself\par
+(excluding combinations of the Program with other software or hardware)\par
+infringes such Recipient's patent(s), then such Recipient's rights granted\par
+under Section 2(b) shall terminate as of the date such litigation is filed.\par
+\par
+All Recipient's rights under this Agreement shall terminate if it fails to\par
+comply with any of the material terms or conditions of this Agreement and\par
+does not cure such failure in a reasonable period of time after becoming\par
+aware of such noncompliance. If all Recipient's rights under this Agreement\par
+terminate, Recipient agrees to cease use and distribution of the Program as\par
+soon as reasonably practicable. However, Recipient's obligations under this\par
+Agreement and any licenses granted by Recipient relating to the Program shall\par
+continue and survive.\par
+\par
+Everyone is permitted to copy and distribute copies of this Agreement, but in\par
+order to avoid inconsistency the Agreement is copyrighted and may only be\par
+modified in the following manner. The Agreement Steward reserves the right to\par
+publish new versions (including revisions) of this Agreement from time to\par
+time. No one other than the Agreement Steward has the right to modify this\par
+Agreement. The Eclipse Foundation is the initial Agreement Steward. The\par
+Eclipse Foundation may assign the responsibility to serve as the Agreement\par
+Steward to a suitable separate entity. Each new version of the Agreement will\par
+be given a distinguishing version number. The Program (including\par
+Contributions) may always be distributed subject to the version of the\par
+Agreement under which it was received. In addition, after a new version of\par
+the Agreement is published, Contributor may elect to distribute the Program\par
+(including its Contributions) under the new version. Except as expressly\par
+stated in Sections 2(a) and 2(b) above, Recipient receives no rights or\par
+licenses to the intellectual property of any Contributor under this\par
+Agreement, whether expressly, by implication, estoppel or otherwise. All\par
+rights in the Program not expressly granted under this Agreement are\par
+reserved.\par
+\par
+This Agreement is governed by the laws of the State of New York and the\par
+intellectual property laws of the United States of America. No party to this\par
+Agreement will bring a legal action under this Agreement more than one year\par
+after the cause of action arose. Each party waives its rights to a jury trial\par
+in any resulting litigation.\par
+}
+ 

--- a/.github/resources/MSI Template.wxs
+++ b/.github/resources/MSI Template.wxs
@@ -1,40 +1,40 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
-    <Product Id="*" Name="Beat Link Trigger" Language="1033" Version="$(var.bltversion)" Manufacturer="Deep Symmetry, LLC" UpgradeCode="6D58C8D7-6163-43C6-93DC-A4C8CC1F81B6">
-        <Package InstallerVersion="200" Compressed="yes" Platform="x64" />
-        <Upgrade Id="6D58C8D7-6163-43C6-93DC-A4C8CC1F81B6" />
+    <Product Id="*" Name="$(var.AppName)" Language="1033" Version="$(var.AppVersion)" Manufacturer="$(var.AppVendor)" UpgradeCode="$(var.AppUpgradeCode)">
+        <Package InstallerVersion="200" Compressed="yes" Platform="x64" Description="$(var.AppDescription)" Manufacturer="$(var.AppVendor)" />
+        <Upgrade Id="$(var.AppUpgradeCode)" />
         <MajorUpgrade Schedule="afterInstallInitialize" AllowDowngrades="no" AllowSameVersionUpgrades="yes" DowngradeErrorMessage="A newer version of [ProductName] is already installed." />
-        <Media Id="1" Cabinet="BeatLinkTrigger.cab" EmbedCab="yes" />
+        <Media Id="1" Cabinet="Data.cab" EmbedCab="yes" />
         <Directory Id="TARGETDIR" Name="SourceDir">
             <Directory Id="ProgramFiles64Folder" Name="PFiles64">
                 <Directory Id="ProgramMenuFolder">
-                    <Directory Id="ProgramMenuDir" Name="Deep Symmetry">
+                    <Directory Id="ProgramMenuDir" Name="$(var.AppVendorFolder)">
                         <Component Id="StartMenuShortcuts" Guid="0A548DE0-FE47-40E2-BEAF-8E35E5AA07F3">
                             <RemoveFolder Id="ProgramMenuDir" On="uninstall" />
                             <RegistryValue Root="HKCU" Key="Software\[Manufacturer]\[ProductName]" Type="string" Value="" />
-                            <Shortcut Id="BeatLinkTrigger" Name="Beat Link Trigger" Description="Start Beat Link Trigger" Target="[DEEP_SYMMETRY]\Beat Link Trigger\BEAT LINK TRIGGER.EXE" Icon="Beat_Link_Trigger.ico">
+                            <Shortcut Id="AppShortcut" Name="$(var.AppName)" Description="Start $(var.AppName)" Target="[App_Vendor_Folder]\[ProductName]\[ProductName].EXE" Icon="$(var.AppIcon)">
                             </Shortcut>
                         </Component>
                     </Directory>
                 </Directory>
-                <Directory Id="DEEP_SYMMETRY" Name="Deep Symmetry">
+                <Directory Id="App_Vendor_Folder" Name="$(var.AppVendorFolder)">
                 </Directory>
 			</Directory>
         </Directory>
         <Feature Id="DefaultFeature" Title="Main Feature" Level="1">
             <ComponentRef Id="StartMenuShortcuts" />
-			<ComponentGroupRef Id="BEAT_LINK_TRIGGER" />
+			<ComponentGroupRef Id="Application_Folder" />
         </Feature>
         <UI />
-        <Property Id="WIXUI_INSTALLDIR" Value="DEEP_SYMMETRY" />
-        <Property Id="ARPPRODUCTICON" Value="Beat_Link_Trigger.ico" />
+        <Property Id="WIXUI_INSTALLDIR" Value="App_Vendor_Folder" />
+        <Property Id="ARPPRODUCTICON" Value="$(var.AppIcon)" />
         <WixVariable Id="WixUILicenseRtf" Value=".\.github\resources\LICENSE.RTF" />
         <UIRef Id="WixUI_InstallDir" />
-        <Icon Id="Beat_Link_Trigger.ico" SourceFile=".\.github\resources\BeatLink.ico" />
+        <Icon Id="$(var.AppIcon)" SourceFile=".\.github\resources\$(var.AppIcon)" />
         <InstallExecuteSequence>
             <FindRelatedProducts />
         </InstallExecuteSequence>
-        <Condition Message="This installer is only supported on Windows 10 64 Bit. You will still be able to use Beat Link Trigger if you download and install Orace Java Runtime Environment (JRE) yourself. After that you can run the .jar file which can be downloaded at the Beat Link Trigger project on Github">
+        <Condition Message="This installer is only supported on Windows 10 64 Bit. You will still be able to use [ProductName] if you download and install Orace Java Runtime Environment (JRE) yourself. After that you can run the .jar file which can be downloaded at the Beat Link Trigger project on Github">
 			<![CDATA[Installed OR VersionNT64]]>
 		</Condition>
     </Product>

--- a/.github/scripts/build_msi.ps1
+++ b/.github/scripts/build_msi.ps1
@@ -25,6 +25,8 @@ jpackage --name "$env:blt_name" --input .\Input --runtime-image .\Runtime `
   --description "$env:blt_description" --copyright "$env:blt_copyright" --vendor "$env:blt_vendor" `
  --app-version "$env:build_version"
 
+#Get the Wix-Toolset file for Beat Link Trigger
+copy ".\.github\resources\Beat Link Trigger.wxs" ".\"
 
 ## Wix-Toolset Party Time!
 #Index all files in the Beat Link Trigger directory

--- a/.github/scripts/build_msi.ps1
+++ b/.github/scripts/build_msi.ps1
@@ -11,6 +11,11 @@ If (! (Test-Path "Runtime")) {
         --add-modules="$env:blt_java_modules" --output .\Runtime
 }
 
+
+# Testing out 4 digit MSI version theory
+$env:build_version = "$env:build_version" + ".0"
+
+
 # Move the downloaded cross-platform executable Jar into an Input folder to be used in building the
 # native app bundle.
 mkdir Input

--- a/.github/scripts/build_msi.ps1
+++ b/.github/scripts/build_msi.ps1
@@ -46,14 +46,14 @@ jpackage --name "$env:blt_name" --input .\Input --runtime-image .\Runtime `
  --app-version "$env:build_version"
 
 #Get the Wix-Toolset file for Beat Link Trigger
-copy ".\.github\resources\Beat Link Trigger.wxs" ".\"
+copy ".\.github\resources\MSI Template.wxs" ".\"
 
 ## Wix-Toolset Party Time!
 #Index all files in the Beat Link Trigger directory
-& $Heat dir "Beat Link Trigger" -cg BEAT_LINK_TRIGGER -dr DEEP_SYMMETRY -gg -ke -sfrag -sreg -template fragment -out beat_link_trigger.wxs
+& $Heat dir $env:blt_name -cg Application_Folder -dr App_Vendor_Folder -gg -ke -sfrag -sreg -template fragment -out "application_folder.wxs"
 
 #Create Wix-Toolset Object file
-& $Candle -dbltversion=""$env:build_version"" -nologo *.wxs -ext WixUIExtension -arch x64
+& $Candle -dAppName=""$env:blt_name"" -dAppVersion=""$env:build_version"" -dAppVendor=""$env:blt_vendor"" -dAppUpgradeCode=""$env:blt_upgradecode"" -dAppDescription=""$env:blt_description"" -dAppVendorFolder=""$env:blt_vendor_folder"" -dAppIcon=""$env:blt_icon"" -nologo *.wxs -ext WixUIExtension -arch x64
 
 #Compile MSI
 & $Light -b "Beat Link Trigger" -nologo "*.wixobj" -out  ""$env:artifact_name"" -ext WixUIExtension

--- a/.github/scripts/build_msi.ps1
+++ b/.github/scripts/build_msi.ps1
@@ -1,3 +1,23 @@
+# Define Wix-Toolset
+$Heat = "${env:ProgramFiles(x86)}\WiX Toolset v3.11\bin\heat.exe"
+$Candle = "${env:ProgramFiles(x86)}\WiX Toolset v3.11\bin\candle.exe"
+$Light = "${env:ProgramFiles(x86)}\WiX Toolset v3.11\bin\light.exe"
+
+# Check for Heat.exe
+if (!(Test-Path $Heat)) {
+  Write-Warning "Heat location not found, please check if Wix-Toolset is installed correctly"
+}
+
+# Check for Candle.exe
+if (!(Test-Path $Candle)) {
+  Write-Warning "Candle location not found, please check if Wix-Toolset is installed correctly"
+}
+
+# Check for Light.exe
+if (!(Test-Path $Light)) {
+  Write-Warning "Light location not found, please check if Wix-Toolset is installed correctly"
+}
+
 # Download and expand the Amazon Corretto 11 JDK, then use it to build the embedded JRE for inside
 # the Mac application. But if it already exists (because we use a cache action to speed things up),
 # we can skip this section.
@@ -30,10 +50,10 @@ copy ".\.github\resources\Beat Link Trigger.wxs" ".\"
 
 ## Wix-Toolset Party Time!
 #Index all files in the Beat Link Trigger directory
-Heat.exe dir "Beat Link Trigger" -cg BEAT_LINK_TRIGGER -dr DEEP_SYMMETRY -gg -ke -sfrag -sreg -template fragment -out beat_link_trigger.wxs
+& $Heat dir "Beat Link Trigger" -cg BEAT_LINK_TRIGGER -dr DEEP_SYMMETRY -gg -ke -sfrag -sreg -template fragment -out beat_link_trigger.wxs
 
 #Create Wix-Toolset Object file
-Candle.exe -dbltversion=""$env:build_version"" -nologo *.wxs -ext WixUIExtension
+& $Candle -dbltversion=""$env:build_version"" -nologo *.wxs -ext WixUIExtension
 
 #Compile MSI
-Light.exe -b "Beat Link Trigger" -nologo "*.wixobj" -out  ""$env:artifact_name"" -ext WixUIExtension
+& $Light -b "Beat Link Trigger" -nologo "*.wixobj" -out  ""$env:artifact_name"" -ext WixUIExtension

--- a/.github/scripts/build_msi.ps1
+++ b/.github/scripts/build_msi.ps1
@@ -53,7 +53,7 @@ copy ".\.github\resources\Beat Link Trigger.wxs" ".\"
 & $Heat dir "Beat Link Trigger" -cg BEAT_LINK_TRIGGER -dr DEEP_SYMMETRY -gg -ke -sfrag -sreg -template fragment -out beat_link_trigger.wxs
 
 #Create Wix-Toolset Object file
-& $Candle -dbltversion=""$env:build_version"" -nologo *.wxs -ext WixUIExtension
+& $Candle -dbltversion=""$env:build_version"" -nologo *.wxs -ext WixUIExtension -arch x64
 
 #Compile MSI
 & $Light -b "Beat Link Trigger" -nologo "*.wixobj" -out  ""$env:artifact_name"" -ext WixUIExtension

--- a/.github/workflows/uberjar.yml
+++ b/.github/workflows/uberjar.yml
@@ -15,7 +15,7 @@ env:
   blt_java_modules: java.base,java.desktop,java.management,java.naming,java.prefs,java.sql,jdk.zipfs,jdk.unsupported
   blt_vendor: Deep Symmetry, LLC
   blt_vendor_folder: Deep Symmetry
-  blt_icon: Beat Link Trigger.ico
+  blt_icon: BeatLink.ico
   blt_upgradecode: 6D58C8D7-6163-43C6-93DC-A4C8CC1F81B6
   initial_description: |
     :construction: This is pre-release code for people who want to help test [what is going into the next release](https://github.com/Deep-Symmetry/beat-link-trigger/blob/master/CHANGELOG.md).

--- a/.github/workflows/uberjar.yml
+++ b/.github/workflows/uberjar.yml
@@ -14,6 +14,9 @@ env:
   blt_mac_notarization_user: "james@deepsymmetry.org"
   blt_java_modules: java.base,java.desktop,java.management,java.naming,java.prefs,java.sql,jdk.zipfs,jdk.unsupported
   blt_vendor: Deep Symmetry, LLC
+  blt_vendor_folder: Deep Symmetry
+  blt_icon: Beat Link Trigger.ico
+  blt_upgradecode: 6D58C8D7-6163-43C6-93DC-A4C8CC1F81B6
   initial_description: |
     :construction: This is pre-release code for people who want to help test [what is going into the next release](https://github.com/Deep-Symmetry/beat-link-trigger/blob/master/CHANGELOG.md).
 

--- a/.github/workflows/uberjar.yml
+++ b/.github/workflows/uberjar.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - Fix-MSI-Upgrade
 
 env:
   blt_name: Beat Link Trigger

--- a/.github/workflows/uberjar.yml
+++ b/.github/workflows/uberjar.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - Fix-MSI-Upgrade
 
 env:
   blt_name: Beat Link Trigger


### PR DESCRIPTION
Because JPackage didn't upgrade over the older BLT MSI's created earlier, we've created a work-a-round to no longer use JPackage as the MSI creator. Instead we now let JPackge create a Application Image (.exe), we then create a MSI from that folder using the Wix-Toolset. Since the added Wix-Toolset Template does allow clients to upgrade over earlier versions this is more friendly for the userbase.

Also changed the Wix Template to use more Environmental Variables, so that less change is needed within the Template file itself.