### PR TITLE
Phrase cues from cue library now retain color information

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,8 @@ pom.xml.asc
 .hg/
 .idea
 beat-link-trigger.iml
-
+.github/scripts/**/*
+*.log
+.cache
 # Local Netlify folder
 .netlify

--- a/src/beat_link_trigger/show_cues.clj
+++ b/src/beat_link_trigger/show_cues.clj
@@ -554,7 +554,7 @@
   Returns a tuple of the name by which it will be stored, and the
   content to be stored (or compared to see if it matches another cue)."
   [cue]
-   [(:comment cue) (dissoc cue :uuid :start :end :hue :linked :section)])
+   [(:comment cue) (dissoc cue :uuid :start :end :linked :section)])
 
 (defn linked-cues-equal?
   "Checks whether all the supplied cues have the same values for any
@@ -1541,7 +1541,7 @@
                                     new-cue             (merge cue {:uuid    uuid
                                                                     :start   start
                                                                     :end     end
-                                                                    :hue     (assign-cue-hue context)
+                                                                    :hue     (get-in cue [:hue])
                                                                     :comment new-name
                                                                     :linked  cue-name}
                                                                (when section {:section section}))]


### PR DESCRIPTION
Inserting Phrase Cues from the Library now retain the hue color of the original item, making visual identification of identical cues easier.

I've tested this locally and it works as intended. 
But I dont know enough about the project (yet) to identify potential side effects, but the changes are miniscule :)


Resolves #143.